### PR TITLE
feat: add edit and delete report UI for own reports

### DIFF
--- a/lib/core/utils/user_facing_error.dart
+++ b/lib/core/utils/user_facing_error.dart
@@ -51,6 +51,12 @@ class UserFacingError {
   static String submitReport(Object error) =>
       message(error, fallback: 'Nie udało się wysłać zgłoszenia.');
 
+  static String editReport(Object error) =>
+      message(error, fallback: 'Nie udało się zaktualizować zgłoszenia.');
+
+  static String deleteReport(Object error) =>
+      message(error, fallback: 'Nie udało się usunąć zgłoszenia.');
+
   static String upvote(Object error) =>
       message(error, fallback: 'Nie udało się oddać głosu.');
 

--- a/lib/features/reports/screens/edit_report_screen.dart
+++ b/lib/features/reports/screens/edit_report_screen.dart
@@ -1,7 +1,5 @@
 import 'dart:io';
-import 'package:flutter/material.dart';
-import 'package:google_maps_flutter/google_maps_flutter.dart';
-import 'package:geolocator/geolocator.dart';
+
 import 'package:city_issues/core/utils/report_utils.dart';
 import 'package:city_issues/core/utils/scroll_padding.dart';
 import 'package:city_issues/core/utils/user_facing_error.dart';
@@ -12,38 +10,38 @@ import 'package:city_issues/features/reports/widgets/report_location_picker.dart
 import 'package:city_issues/services/camera_service.dart';
 import 'package:city_issues/services/location_service.dart';
 import 'package:city_issues/services/report_service.dart';
+import 'package:flutter/material.dart';
+import 'package:geolocator/geolocator.dart';
+import 'package:google_maps_flutter/google_maps_flutter.dart';
 
-class CreateReportScreen extends StatefulWidget {
-  const CreateReportScreen({
-    super.key,
-    this.initialLocation,
-    this.embedded = false,
-    this.onClose,
-    this.onSubmitted,
-  });
+class _ExistingPhoto {
+  _ExistingPhoto({required this.id, required this.url});
 
-  final LatLng? initialLocation;
-  final bool embedded;
-  final VoidCallback? onClose;
-  final VoidCallback? onSubmitted;
-
-  @override
-  State<CreateReportScreen> createState() => _CreateReportScreenState();
+  final String id;
+  final String url;
+  bool markedForRemoval = false;
 }
 
-class _CreateReportScreenState extends State<CreateReportScreen> {
-  static const LatLng _defaultPosition = LatLng(52.2297, 21.0122);
+class EditReportScreen extends StatefulWidget {
+  const EditReportScreen({super.key, required this.report});
 
+  final GetReportsReports report;
+
+  @override
+  State<EditReportScreen> createState() => _EditReportScreenState();
+}
+
+class _EditReportScreenState extends State<EditReportScreen> {
   final TextEditingController _descController = TextEditingController();
 
   List<GetCategoriesCategories> _categories = [];
   String? _selectedCategoryId;
-  final List<File> _photos = [];
+  final List<_ExistingPhoto> _existingPhotos = [];
+  final List<File> _newPhotos = [];
 
   LatLng? _location;
-  bool _locationLoading = true;
+  bool _locationLoading = false;
   String? _locationError;
-  bool _requireMapInteraction = false;
 
   final _locationPickerKey = GlobalKey<ReportLocationPickerState>();
 
@@ -51,45 +49,52 @@ class _CreateReportScreenState extends State<CreateReportScreen> {
   bool _isSubmitting = false;
   String? _submitError;
 
+  int get _remainingPhotoCount =>
+      _existingPhotos.where((p) => !p.markedForRemoval).length + _newPhotos.length;
+
   bool get _canSubmit =>
       !_isSubmitting &&
       !_categoriesLoading &&
-      !_locationLoading &&
       _selectedCategoryId != null &&
       _location != null &&
-      _photos.isNotEmpty;
+      _remainingPhotoCount > 0;
 
   @override
   void initState() {
     super.initState();
-    _loadCategories();
-    if (widget.initialLocation != null) {
-      _location = widget.initialLocation;
-      _locationLoading = false;
-    } else {
-      _loadLocation();
+    _descController.text = widget.report.description ?? '';
+    _location = LatLng(widget.report.latitude, widget.report.longitude);
+    for (final photo in widget.report.reportPhotos_on_report) {
+      _existingPhotos.add(_ExistingPhoto(id: photo.id, url: photo.imageUrl));
     }
+    _loadCategories();
   }
-
-  LatLng get _mapInitialTarget => _location ?? _defaultPosition;
 
   Future<void> _loadCategories() async {
     try {
       final categories = await ReportService.instance.getCategories();
-      if (mounted) {
-        setState(() {
-          _categories = categories;
-          _categoriesLoading = false;
-        });
-      }
+      if (!mounted) return;
+      setState(() {
+        _categories = categories;
+        _categoriesLoading = false;
+        _selectedCategoryId = _resolveCategoryId(categories);
+      });
     } catch (e) {
-      if (mounted) {
-        setState(() {
-          _categoriesLoading = false;
-          _submitError = UserFacingError.loadCategories(e);
-        });
+      if (!mounted) return;
+      setState(() {
+        _categoriesLoading = false;
+        _submitError = UserFacingError.loadCategories(e);
+      });
+    }
+  }
+
+  String? _resolveCategoryId(List<GetCategoriesCategories> categories) {
+    for (final category in categories) {
+      if (category.name == widget.report.category.name) {
+        return category.id;
       }
     }
+    return categories.isNotEmpty ? categories.first.id : null;
   }
 
   Future<void> _loadLocation() async {
@@ -100,24 +105,19 @@ class _CreateReportScreenState extends State<CreateReportScreen> {
     try {
       final Position position =
           await LocationService.instance.getCurrentLocation();
-      if (mounted) {
-        final latLng = LatLng(position.latitude, position.longitude);
-        setState(() {
-          _location = latLng;
-          _locationLoading = false;
-          _requireMapInteraction = false;
-        });
-        _locationPickerKey.currentState?.recenterTo(latLng);
-      }
+      if (!mounted) return;
+      final latLng = LatLng(position.latitude, position.longitude);
+      setState(() {
+        _location = latLng;
+        _locationLoading = false;
+      });
+      _locationPickerKey.currentState?.recenterTo(latLng);
     } catch (e) {
-      if (mounted) {
-        setState(() {
-          _locationError = UserFacingError.location(e);
-          _location = null;
-          _locationLoading = false;
-          _requireMapInteraction = true;
-        });
-      }
+      if (!mounted) return;
+      setState(() {
+        _locationError = UserFacingError.location(e);
+        _locationLoading = false;
+      });
     }
   }
 
@@ -131,7 +131,7 @@ class _CreateReportScreenState extends State<CreateReportScreen> {
   Future<void> _addPhoto() async {
     final File? photo = await CameraService.instance.showPickerDialog(context);
     if (photo != null) {
-      setState(() => _photos.add(photo));
+      setState(() => _newPhotos.add(photo));
     }
   }
 
@@ -144,57 +144,41 @@ class _CreateReportScreenState extends State<CreateReportScreen> {
     });
 
     try {
-      await ReportService.instance.createReport(
+      await ReportService.instance.editReport(
+        reportId: widget.report.id,
         categoryId: _selectedCategoryId!,
         description: _descController.text.trim().isEmpty
             ? null
             : _descController.text.trim(),
-        photos: _photos,
-        selectedLocation: _location
+        location: _location!,
+        photos: _newPhotos,
+        removedPhotoIds: _existingPhotos
+            .where((p) => p.markedForRemoval)
+            .map((p) => p.id)
+            .toList(),
       );
 
-      if (mounted) {
-        ScaffoldMessenger.of(context).showSnackBar(
-          const SnackBar(content: Text('Zgłoszenie zostało wysłane.')),
-        );
-        if (widget.embedded) {
-          widget.onSubmitted?.call();
-        } else {
-          Navigator.pop(context, true);
-        }
-      }
+      if (!mounted) return;
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(content: Text('Zgłoszenie zostało zaktualizowane.')),
+      );
+      Navigator.pop(context, true);
     } catch (e) {
-      setState(() => _submitError = UserFacingError.submitReport(e));
+      if (!mounted) return;
+      setState(() => _submitError = UserFacingError.editReport(e));
     } finally {
       if (mounted) setState(() => _isSubmitting = false);
     }
   }
 
-  void _handleBack() {
-    if (widget.embedded) {
-      widget.onClose?.call();
-    } else {
-      Navigator.maybePop(context);
-    }
-  }
-
   @override
   Widget build(BuildContext context) {
-    final scaffold = Scaffold(
-      appBar: AppBar(
-        title: const Text('Nowe zgłoszenie'),
-        leading: widget.embedded
-            ? IconButton(
-                icon: const Icon(Icons.arrow_back),
-                tooltip: 'Wróć',
-                onPressed: _handleBack,
-              )
-            : null,
-      ),
+    return Scaffold(
+      appBar: AppBar(title: const Text('Edytuj zgłoszenie')),
       body: _categoriesLoading
           ? const AppLoading(message: 'Ładowanie formularza...')
           : SingleChildScrollView(
-              padding: ScrollPadding.list(context, includeNavBar: widget.embedded),
+              padding: ScrollPadding.list(context, includeNavBar: true),
               child: Column(
                 crossAxisAlignment: CrossAxisAlignment.stretch,
                 children: [
@@ -235,10 +219,10 @@ class _CreateReportScreenState extends State<CreateReportScreen> {
                     maxLength: 500,
                   ),
                   const SizedBox(height: 8),
-                  Text('Zdjęcie *', style: Theme.of(context).textTheme.titleMedium),
+                  Text('Zdjęcia *', style: Theme.of(context).textTheme.titleMedium),
                   const SizedBox(height: 4),
                   Text(
-                    'Dodaj co najmniej jedno zdjęcie problemu.',
+                    'Zgłoszenie musi mieć co najmniej jedno zdjęcie.',
                     style: Theme.of(context).textTheme.bodySmall?.copyWith(
                           color: Theme.of(context).colorScheme.outline,
                         ),
@@ -249,8 +233,7 @@ class _CreateReportScreenState extends State<CreateReportScreen> {
                   Text('Lokalizacja *', style: Theme.of(context).textTheme.titleMedium),
                   const SizedBox(height: 4),
                   Text(
-                    'Przesuń mapę tak, aby pinezka wskazywała miejsce zgłoszenia. '
-                    'Możesz też pobrać lokalizację z GPS.',
+                    'Przesuń mapę tak, aby pinezka wskazywała miejsce zgłoszenia.',
                     style: Theme.of(context).textTheme.bodySmall?.copyWith(
                           color: Theme.of(context).colorScheme.outline,
                         ),
@@ -270,14 +253,12 @@ class _CreateReportScreenState extends State<CreateReportScreen> {
                             width: 24,
                             child: CircularProgressIndicator(strokeWidth: 2),
                           )
-                        : const Text('Wyślij zgłoszenie'),
+                        : const Text('Zapisz zmiany'),
                   ),
                 ],
               ),
             ),
     );
-
-    return scaffold;
   }
 
   Widget _buildPhotos() {
@@ -285,7 +266,40 @@ class _CreateReportScreenState extends State<CreateReportScreen> {
       spacing: 8,
       runSpacing: 8,
       children: [
-        ..._photos.map(
+        ..._existingPhotos.where((p) => !p.markedForRemoval).map(
+              (photo) => Stack(
+                children: [
+                  ClipRRect(
+                    borderRadius: BorderRadius.circular(8),
+                    child: Image.network(
+                      photo.url,
+                      width: 100,
+                      height: 100,
+                      fit: BoxFit.cover,
+                      errorBuilder: (_, __, ___) => Container(
+                        width: 100,
+                        height: 100,
+                        color: Theme.of(context).colorScheme.surfaceContainerHighest,
+                        child: const Icon(Icons.broken_image_outlined),
+                      ),
+                    ),
+                  ),
+                  Positioned(
+                    top: 4,
+                    right: 4,
+                    child: GestureDetector(
+                      onTap: () => setState(() => photo.markedForRemoval = true),
+                      child: const CircleAvatar(
+                        radius: 12,
+                        backgroundColor: Colors.red,
+                        child: Icon(Icons.close, size: 14, color: Colors.white),
+                      ),
+                    ),
+                  ),
+                ],
+              ),
+            ),
+        ..._newPhotos.map(
           (photo) => Stack(
             children: [
               ClipRRect(
@@ -296,7 +310,7 @@ class _CreateReportScreenState extends State<CreateReportScreen> {
                 top: 4,
                 right: 4,
                 child: GestureDetector(
-                  onTap: () => setState(() => _photos.remove(photo)),
+                  onTap: () => setState(() => _newPhotos.remove(photo)),
                   child: const CircleAvatar(
                     radius: 12,
                     backgroundColor: Colors.red,
@@ -334,6 +348,8 @@ class _CreateReportScreenState extends State<CreateReportScreen> {
       return const SizedBox(height: 200, child: AppLoading(message: 'Pobieranie GPS...'));
     }
 
+    final target = _location ?? LatLng(widget.report.latitude, widget.report.longitude);
+
     return Column(
       crossAxisAlignment: CrossAxisAlignment.stretch,
       children: [
@@ -347,8 +363,7 @@ class _CreateReportScreenState extends State<CreateReportScreen> {
             height: 200,
             child: ReportLocationPicker(
               key: _locationPickerKey,
-              initialTarget: _mapInitialTarget,
-              requireUserInteraction: _requireMapInteraction,
+              initialTarget: target,
               onLocationChanged: _onPickerLocationChanged,
             ),
           ),
@@ -358,13 +373,6 @@ class _CreateReportScreenState extends State<CreateReportScreen> {
           Text(
             'Współrzędne: ${_location!.latitude.toStringAsFixed(5)}, ${_location!.longitude.toStringAsFixed(5)}',
             style: Theme.of(context).textTheme.bodySmall,
-          )
-        else
-          Text(
-            'Przesuń mapę, aby wskazać miejsce zgłoszenia.',
-            style: Theme.of(context).textTheme.bodySmall?.copyWith(
-                  color: Theme.of(context).colorScheme.outline,
-                ),
           ),
         TextButton.icon(
           onPressed: _loadLocation,

--- a/lib/features/reports/screens/my_reports_screen.dart
+++ b/lib/features/reports/screens/my_reports_screen.dart
@@ -1,3 +1,4 @@
+import 'package:city_issues/features/reports/widgets/report_manage_actions.dart';
 import 'package:city_issues/services/report_service.dart';
 import 'package:flutter/material.dart';
 import 'package:city_issues/core/utils/report_utils.dart';
@@ -9,9 +10,16 @@ import 'package:city_issues/core/utils/scroll_padding.dart';
 import 'package:city_issues/core/utils/user_facing_error.dart';
 
 class MyReportsScreen extends StatefulWidget {
-  const MyReportsScreen({super.key, required this.onOpenReportDetail});
+  const MyReportsScreen({
+    super.key,
+    required this.onOpenReportDetail,
+    this.onEditReport,
+    this.onReportDeleted,
+  });
 
   final void Function(GetReportsReports report) onOpenReportDetail;
+  final void Function(GetReportsReports report)? onEditReport;
+  final VoidCallback? onReportDeleted;
 
   @override
   MyReportsScreenState createState() => MyReportsScreenState();
@@ -43,6 +51,35 @@ class MyReportsScreenState extends State<MyReportsScreen> {
       if (mounted) setState(() => _error = UserFacingError.loadMyReports(e));
     } finally {
       if (mounted) setState(() => _isLoading = false);
+    }
+  }
+
+  Future<void> _confirmDelete(GetReportsReports report) async {
+    final confirmed = await showReportDeleteDialog(context);
+    if (confirmed != true || !mounted) return;
+
+    try {
+      await ReportService.instance.deleteReport(report.id);
+      if (!mounted) return;
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(content: Text('Zgłoszenie zostało usunięte.')),
+      );
+      widget.onReportDeleted?.call();
+      await _load(forceRefresh: true);
+    } catch (e) {
+      if (!mounted) return;
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(content: Text(UserFacingError.deleteReport(e))),
+      );
+    }
+  }
+
+  void _handleMenuAction(String action, GetReportsReports report) {
+    switch (action) {
+      case 'edit':
+        widget.onEditReport?.call(report);
+      case 'delete':
+        _confirmDelete(report);
     }
   }
 
@@ -107,20 +144,46 @@ class MyReportsScreenState extends State<MyReportsScreen> {
               maxLines: 2,
               overflow: TextOverflow.ellipsis,
             ),
-            trailing: Container(
-              padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
-              decoration: BoxDecoration(
-                color: ReportUtils.statusColor(report.status).withValues(alpha: 0.15),
-                borderRadius: BorderRadius.circular(12),
-              ),
-              child: Text(
-                ReportUtils.statusLabel(report.status),
-                style: TextStyle(
-                  color: ReportUtils.statusColor(report.status),
-                  fontSize: 12,
-                  fontWeight: FontWeight.w600,
+            trailing: Row(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                Container(
+                  padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
+                  decoration: BoxDecoration(
+                    color: ReportUtils.statusColor(report.status).withValues(alpha: 0.15),
+                    borderRadius: BorderRadius.circular(12),
+                  ),
+                  child: Text(
+                    ReportUtils.statusLabel(report.status),
+                    style: TextStyle(
+                      color: ReportUtils.statusColor(report.status),
+                      fontSize: 12,
+                      fontWeight: FontWeight.w600,
+                    ),
+                  ),
                 ),
-              ),
+                PopupMenuButton<String>(
+                  onSelected: (value) => _handleMenuAction(value, report),
+                  itemBuilder: (_) => const [
+                    PopupMenuItem(
+                      value: 'edit',
+                      child: ListTile(
+                        leading: Icon(Icons.edit_outlined),
+                        title: Text('Edytuj'),
+                        contentPadding: EdgeInsets.zero,
+                      ),
+                    ),
+                    PopupMenuItem(
+                      value: 'delete',
+                      child: ListTile(
+                        leading: Icon(Icons.delete_outline, color: Colors.red),
+                        title: Text('Usuń', style: TextStyle(color: Colors.red)),
+                        contentPadding: EdgeInsets.zero,
+                      ),
+                    ),
+                  ],
+                ),
+              ],
             ),
             onTap: () => widget.onOpenReportDetail(report),
           );

--- a/lib/features/reports/screens/report_detail_screen.dart
+++ b/lib/features/reports/screens/report_detail_screen.dart
@@ -1,6 +1,9 @@
+import 'package:city_issues/features/reports/widgets/report_manage_actions.dart';
+import 'package:city_issues/services/report_service.dart';
 import 'package:flutter/material.dart';
 import 'package:google_maps_flutter/google_maps_flutter.dart';
 import 'package:city_issues/core/utils/report_utils.dart';
+import 'package:city_issues/core/utils/user_facing_error.dart';
 import 'package:city_issues/dataconnect_generated/default.dart';
 import 'package:city_issues/features/reports/widgets/comments_section.dart';
 import 'package:city_issues/services/auth_service.dart';
@@ -8,30 +11,81 @@ import 'package:city_issues/core/utils/scroll_padding.dart';
 import 'package:city_issues/features/reports/widgets/photo_viewer.dart';
 import 'package:city_issues/features/reports/widgets/upvote_button.dart';
 
-class ReportDetailScreen extends StatelessWidget {
+class ReportDetailScreen extends StatefulWidget {
   const ReportDetailScreen({
     super.key,
     required this.report,
     this.onBack,
     this.commentsSection,
     this.upvoteButton,
+    this.canManage = false,
+    this.onEdit,
+    this.onDeleted,
   });
 
   final GetReportsReports report;
   final VoidCallback? onBack;
   final Widget? commentsSection;
   final Widget? upvoteButton;
+  final bool canManage;
+  final VoidCallback? onEdit;
+  final VoidCallback? onDeleted;
+
+  @override
+  State<ReportDetailScreen> createState() => _ReportDetailScreenState();
+}
+
+class _ReportDetailScreenState extends State<ReportDetailScreen> {
+  bool _isDeleting = false;
+
+  Future<void> _confirmDelete() async {
+    final confirmed = await showReportDeleteDialog(context);
+    if (confirmed != true || !mounted) return;
+
+    setState(() => _isDeleting = true);
+    try {
+      await ReportService.instance.deleteReport(widget.report.id);
+      if (!mounted) return;
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(content: Text('Zgłoszenie zostało usunięte.')),
+      );
+      if (widget.onDeleted != null) {
+        widget.onDeleted!();
+      } else if (widget.onBack != null) {
+        widget.onBack!();
+      } else {
+        Navigator.of(context).pop(true);
+      }
+    } catch (e) {
+      if (!mounted) return;
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(content: Text(UserFacingError.deleteReport(e))),
+      );
+    } finally {
+      if (mounted) setState(() => _isDeleting = false);
+    }
+  }
+
+  void _handleMenuAction(String action) {
+    switch (action) {
+      case 'edit':
+        widget.onEdit?.call();
+      case 'delete':
+        _confirmDelete();
+    }
+  }
 
   @override
   Widget build(BuildContext context) {
+    final report = widget.report;
     final position = LatLng(report.latitude, report.longitude);
     final photos = report.reportPhotos_on_report;
     final photoUrls = photos.map((p) => p.imageUrl).toList();
     final upvoteCount = ReportUtils.upvoteCount(report.upvotes_on_report);
 
     void goBack() {
-      if (onBack != null) {
-        onBack!();
+      if (widget.onBack != null) {
+        widget.onBack!();
       } else {
         Navigator.of(context).pop();
       }
@@ -48,8 +102,44 @@ class ReportDetailScreen extends StatelessWidget {
         title: const Text('Szczegóły zgłoszenia'),
         leading: IconButton(
           icon: const Icon(Icons.arrow_back),
-          onPressed: goBack,
+          onPressed: _isDeleting ? null : goBack,
         ),
+        actions: [
+          if (widget.canManage)
+            PopupMenuButton<String>(
+              enabled: !_isDeleting,
+              onSelected: _handleMenuAction,
+              itemBuilder: (_) => const [
+                PopupMenuItem(
+                  value: 'edit',
+                  child: ListTile(
+                    leading: Icon(Icons.edit_outlined),
+                    title: Text('Edytuj'),
+                    contentPadding: EdgeInsets.zero,
+                  ),
+                ),
+                PopupMenuItem(
+                  value: 'delete',
+                  child: ListTile(
+                    leading: Icon(Icons.delete_outline, color: Colors.red),
+                    title: Text('Usuń', style: TextStyle(color: Colors.red)),
+                    contentPadding: EdgeInsets.zero,
+                  ),
+                ),
+              ],
+            ),
+          if (_isDeleting)
+            const Padding(
+              padding: EdgeInsets.symmetric(horizontal: 16),
+              child: Center(
+                child: SizedBox(
+                  width: 20,
+                  height: 20,
+                  child: CircularProgressIndicator(strokeWidth: 2),
+                ),
+              ),
+            ),
+        ],
       ),
       body: SafeArea(
         child: SingleChildScrollView(
@@ -129,7 +219,7 @@ class ReportDetailScreen extends StatelessWidget {
                       ],
                     ),
                     const SizedBox(height: 12),
-                    upvoteButton ??
+                    widget.upvoteButton ??
                         UpvoteButton(
                           reportId: report.id,
                           initialCount: upvoteCount,
@@ -168,7 +258,7 @@ class ReportDetailScreen extends StatelessWidget {
                       style: Theme.of(context).textTheme.bodySmall,
                     ),
                     const SizedBox(height: 24),
-                    commentsSection ??
+                    widget.commentsSection ??
                         CommentsSection(
                           reportId: report.id,
                           isSignedIn: AuthService.instance.isSignedIn,

--- a/lib/features/reports/widgets/report_location_picker.dart
+++ b/lib/features/reports/widgets/report_location_picker.dart
@@ -1,0 +1,95 @@
+import 'package:flutter/foundation.dart';
+import 'package:flutter/gestures.dart';
+import 'package:flutter/material.dart';
+import 'package:google_maps_flutter/google_maps_flutter.dart';
+
+class ReportLocationPicker extends StatefulWidget {
+  const ReportLocationPicker({
+    super.key,
+    required this.initialTarget,
+    required this.onLocationChanged,
+    this.requireUserInteraction = false,
+  });
+
+  final LatLng initialTarget;
+  final ValueChanged<LatLng> onLocationChanged;
+  final bool requireUserInteraction;
+
+  @override
+  State<ReportLocationPicker> createState() => ReportLocationPickerState();
+}
+
+class ReportLocationPickerState extends State<ReportLocationPicker> {
+  GoogleMapController? _controller;
+  LatLng? _pendingCenter;
+  late final CameraPosition _initialCamera;
+  bool _userMovedCamera = false;
+
+  static final _gestureRecognizers = <Factory<OneSequenceGestureRecognizer>>{
+    Factory<OneSequenceGestureRecognizer>(() => EagerGestureRecognizer()),
+  };
+
+  @override
+  void initState() {
+    super.initState();
+    _initialCamera = CameraPosition(target: widget.initialTarget, zoom: 16);
+  }
+
+  @override
+  void didUpdateWidget(covariant ReportLocationPicker oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (!widget.requireUserInteraction && oldWidget.requireUserInteraction) {
+      _userMovedCamera = false;
+    }
+  }
+
+  void recenterTo(LatLng target) {
+    _controller?.animateCamera(
+      CameraUpdate.newCameraPosition(CameraPosition(target: target, zoom: 16)),
+    );
+  }
+
+  void _notifyLocationIfReady() {
+    final center = _pendingCenter;
+    if (center == null) return;
+    if (widget.requireUserInteraction && !_userMovedCamera) return;
+    widget.onLocationChanged(center);
+  }
+
+  @override
+  void dispose() {
+    _controller?.dispose();
+    _controller = null;
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final pinColor = Theme.of(context).colorScheme.primary;
+
+    return Stack(
+      alignment: Alignment.center,
+      children: [
+        GoogleMap(
+          initialCameraPosition: _initialCamera,
+          gestureRecognizers: _gestureRecognizers,
+          onMapCreated: (controller) => _controller = controller,
+          onCameraMove: (position) {
+            _pendingCenter = position.target;
+            _userMovedCamera = true;
+          },
+          onCameraIdle: _notifyLocationIfReady,
+          myLocationEnabled: true,
+          myLocationButtonEnabled: false,
+          zoomControlsEnabled: false,
+        ),
+        IgnorePointer(
+          child: Transform.translate(
+            offset: const Offset(0, -18),
+            child: Icon(Icons.location_on, size: 44, color: pinColor),
+          ),
+        ),
+      ],
+    );
+  }
+}

--- a/lib/features/reports/widgets/report_manage_actions.dart
+++ b/lib/features/reports/widgets/report_manage_actions.dart
@@ -1,0 +1,28 @@
+import 'package:flutter/material.dart';
+
+Future<bool?> showReportDeleteDialog(BuildContext context) {
+  return showDialog<bool>(
+    context: context,
+    builder: (context) => AlertDialog(
+      title: const Text('Usunąć zgłoszenie?'),
+      content: const Text(
+        'Tej operacji nie można cofnąć. Zgłoszenie wraz ze zdjęciami, '
+        'komentarzami i głosami zostanie trwale usunięte.',
+      ),
+      actions: [
+        TextButton(
+          onPressed: () => Navigator.pop(context, false),
+          child: const Text('Anuluj'),
+        ),
+        FilledButton(
+          style: FilledButton.styleFrom(
+            backgroundColor: Theme.of(context).colorScheme.error,
+            foregroundColor: Theme.of(context).colorScheme.onError,
+          ),
+          onPressed: () => Navigator.pop(context, true),
+          child: const Text('Usuń'),
+        ),
+      ],
+    ),
+  );
+}

--- a/lib/features/shell/main_shell.dart
+++ b/lib/features/shell/main_shell.dart
@@ -4,11 +4,14 @@ import 'package:google_maps_flutter/google_maps_flutter.dart';
 import 'package:city_issues/dataconnect_generated/default.dart';
 import 'package:city_issues/features/map/screens/map_screen.dart';
 import 'package:city_issues/features/onboarding/app_tour.dart';
+import 'package:city_issues/features/reports/screens/edit_report_screen.dart';
 import 'package:city_issues/features/reports/screens/create_report_screen.dart';
 import 'package:city_issues/features/reports/screens/my_reports_screen.dart';
 import 'package:city_issues/features/reports/screens/report_detail_screen.dart';
 import 'package:city_issues/features/settings/screens/settings_screen.dart';
 import 'package:city_issues/services/app_preferences.dart';
+import 'package:city_issues/services/auth_service.dart';
+import 'package:city_issues/services/report_service.dart';
 
 class MainShell extends StatefulWidget {
   const MainShell({super.key});
@@ -126,16 +129,65 @@ class _MainShellState extends State<MainShell> {
     }
   }
 
-  void openReportDetail(GetReportsReports report) {
+  void _refreshReportData() {
+    _mapKey.currentState?.refreshReports(forceRefresh: true);
+    _myReportsKey.currentState?.refresh();
+  }
+
+  Future<bool> _resolveCanManage(String reportId, {bool? canManage}) async {
+    if (canManage != null) return canManage;
+    if (!AuthService.instance.isSignedIn) return false;
+    return ReportService.instance.isOwnReport(reportId);
+  }
+
+  Future<void> openReportDetail(
+    GetReportsReports report, {
+    bool? canManage,
+  }) async {
+    final manage = await _resolveCanManage(report.id, canManage: canManage);
+    if (!mounted) return;
+
     _shellNavigatorKey.currentState?.push(
       MaterialPageRoute(
         settings: const RouteSettings(name: '/report-detail'),
         builder: (_) => ReportDetailScreen(
           report: report,
+          canManage: manage,
           onBack: () => _shellNavigatorKey.currentState?.pop(),
+          onEdit: manage ? () => _openEditReport(report) : null,
+          onDeleted: manage
+              ? () {
+                  _shellNavigatorKey.currentState?.pop(true);
+                  _refreshReportData();
+                }
+              : null,
         ),
       ),
-    );
+    ).then((deleted) {
+      if (deleted == true && manage) {
+        _refreshReportData();
+      }
+    });
+  }
+
+  void _openEditReport(GetReportsReports report) {
+    _shellNavigatorKey.currentState?.push(
+      MaterialPageRoute(
+        settings: const RouteSettings(name: '/report-edit'),
+        builder: (_) => EditReportScreen(report: report),
+      ),
+    ).then((saved) {
+      if (saved == true) {
+        _refreshReportData();
+        _shellNavigatorKey.currentState?.popUntil(
+          (route) => route.settings.name != '/report-detail',
+        );
+      }
+    });
+  }
+
+  void openReportDetailFromMyReports(GetReportsReports report) {
+    openReportDetail(report, canManage: true);
   }
 
   void _openCreateReport({LatLng? initialLocation}) {
@@ -208,7 +260,9 @@ class _MainShellState extends State<MainShell> {
         ),
         MyReportsScreen(
           key: _myReportsKey,
-          onOpenReportDetail: openReportDetail,
+          onOpenReportDetail: openReportDetailFromMyReports,
+          onEditReport: _openEditReport,
+          onReportDeleted: _refreshReportData,
         ),
         SettingsScreen(
           onShowOnboarding: () => openOnboarding(replay: true),

--- a/lib/services/report_service.dart
+++ b/lib/services/report_service.dart
@@ -157,6 +157,12 @@ class ReportService {
   return reports;
 }
 
+  Future<bool> isOwnReport(String reportId) async {
+    if (!_authService.isSignedIn) return false;
+    final myReports = await getMyReports();
+    return myReports.any((report) => report.id == reportId);
+  }
+
   Future<void> createReport({
     required String categoryId,
     String? description,


### PR DESCRIPTION
Add EditReportScreen, manage actions in My Reports and report details, and wire navigation in MainShell using existing ReportService API. Detect report ownership when opening details from the map so edit and delete are available for the author's markers.