### PR TITLE
docs: update README and add frontend documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ Wersja: **0.2.0 (1)**
 - [Konfiguracja](#konfiguracja)
 - [Uruchomienie](#uruchomienie)
 - [Testy](#testy)
+- [Dokumentacja](#dokumentacja)
 - [Struktura projektu](#struktura-projektu)
 - [Zespół](#zespół)
 
@@ -22,6 +23,7 @@ Wersja: **0.2.0 (1)**
 ### Uwierzytelnianie
 
 - Logowanie i rejestracja przez **Google Sign-In** (Firebase Auth)
+- Usuwanie konta wraz z danymi w PostgreSQL i plikami w Storage
 
 ### Mapa zgłoszeń
 
@@ -29,6 +31,7 @@ Wersja: **0.2.0 (1)**
 - Filtry kategorii (kolory pinów z bazy danych)
 - Podgląd zgłoszenia w bottom sheet po kliknięciu markera
 - Przejście do szczegółów zgłoszenia
+- Odświeżanie listy co 30 s oraz po powiadomieniu push
 
 ### Nowe zgłoszenie
 
@@ -46,18 +49,30 @@ Wersja: **0.2.0 (1)**
 
 - Zdjęcia, opis, kategoria, status
 - Mapa z lokalizacją
-- Głosowanie (upvote)
+- Głosowanie (upvote) z optymistycznym UI
+- Komentarze: dodawanie, edycja i usuwanie własnych wpisów
+- Edycja i usuwanie własnego zgłoszenia (kategoria, opis, lokalizacja, zdjęcia)
+
+### Powiadomienia push
+
+- Powiadomienie właściciela zgłoszenia o nowym głosie wsparcia (FCM + Cloud Function)
+- Otwarcie szczegółów zgłoszenia po kliknięciu powiadomienia
+- Włączanie i wyłączanie push w ustawieniach profilu
+
+### Tryb offline (frontend)
+
+- Cache zgłoszeń, kategorii, „moich zgłoszeń” i komentarzy w SQLite
+- Banner informujący o braku sieci
+- Kolejka synchronizacji: głosowanie, cofanie głosu, dodawanie komentarza po powrocie online
+- Tworzenie, edycja i usuwanie zgłoszeń wymagają połączenia z siecią
 
 ### Profil i ustawienia
 
 - Motyw jasny / ciemny / systemowy
 - Kolor akcentu aplikacji
+- Powiadomienia push (włącz / wyłącz)
 - Interaktywny przewodnik po aplikacji (onboarding)
 - Ekran „O aplikacji”
-
-### Planowane
-
-- Komentarze pod zgłoszeniami (obecnie placeholder w UI)
 
 ## Stos technologiczny
 
@@ -67,9 +82,11 @@ Wersja: **0.2.0 (1)**
 | Backend / API | Firebase Data Connect (PostgreSQL) |
 | Uwierzytelnianie | Firebase Auth, Google Sign-In |
 | Pliki | Firebase Storage |
+| Powiadomienia | Firebase Cloud Messaging, Cloud Functions, `flutter_local_notifications` |
 | Mapa | Google Maps Flutter |
 | Lokalizacja | Geolocator |
 | Preferencje lokalne | SharedPreferences |
+| Cache offline | SQLite (`sqflite`), `connectivity_plus` |
 
 ## Wymagania
 
@@ -98,7 +115,7 @@ Pliki z danymi wrażliwymi nie są w repozytorium (patrz `.gitignore`). Trzeba j
 
 3. Pliki `android/app/google-services.json` i `lib/firebase_options.dart` są w `.gitignore` (nie commituj kluczy).
 
-4. W Firebase Console włącz **Authentication** (dostawca Google) oraz **Data Connect** / Storage według potrzeb projektu.
+4. W Firebase Console włącz **Authentication** (dostawca Google), **Data Connect**, **Storage**, **Cloud Messaging** oraz **Cloud Functions** według potrzeb projektu.
 
 ### CI (GitHub Actions)
 
@@ -153,7 +170,7 @@ flutter build apk --debug
 
 ## Testy
 
-Testy podzielone na jednostkowe i widgety:
+Testy jednostkowe i widgetów:
 
 ```bash
 flutter test
@@ -166,32 +183,55 @@ flutter test test/unit/
 flutter test test/widgets/
 ```
 
+Testy integracyjne (wymagają sekretów CI lub lokalnej konfiguracji Firebase):
+
+```bash
+flutter test integration_test/
+```
+
 Struktura:
 
 - `test/unit/` — logika pomocnicza (walidacja, mapowanie błędów)
 - `test/widgets/` — komponenty UI (mapa, formularze, ustawienia)
-- `test/helpers/` — wspólne fixture’y i `pumpWidget` do testów
+- `test/helpers/` — wspólne fixture'y i `pumpWidget` do testów
+- `integration_test/` — scenariusze end-to-end na urządzeniu
+
+## Dokumentacja
+
+| Dokument | Opis |
+|----------|------|
+| [`docs/frontend/README.md`](docs/frontend/README.md) | Architektura frontendu, nawigacja, ekrany, konwencje |
+| [`lib/services/README.md`](lib/services/README.md) | Referencja API warstwy serwisów (Data Connect, offline, FCM) |
+| [`docs/CI-SECRETS.md`](docs/CI-SECRETS.md) | Sekrety GitHub Actions |
+| [`docs/database.dbml`](docs/database.dbml) | Schemat bazy PostgreSQL (diagram) |
+| [`integration_test/README.md`](integration_test/README.md) | Testy integracyjne |
 
 ## Struktura projektu
 
 ```
 lib/
-├── app/                 # MaterialApp, motywy
-├── core/                # stałe, widgety wspólne, utils
+├── app/                    # MaterialApp, motywy, bootstrap Firebase
+├── core/                   # stałe, widgety wspólne, utils
+│   └── widgets/            # m.in. OfflineBanner
 ├── dataconnect_generated/  # SDK wygenerowane z Data Connect
 ├── features/
-│   ├── auth/            # logowanie, AuthGate
-│   ├── map/             # mapa i filtry
-│   ├── onboarding/      # przewodnik po aplikacji
-│   ├── reports/         # zgłoszenia (lista, formularz, szczegóły)
-│   ├── settings/        # profil, o aplikacji
-│   └── shell/           # nawigacja (dolny pasek, IndexedStack)
-├── services/            # auth, raporty, lokalizacja, storage
+│   ├── auth/               # logowanie, AuthGate
+│   ├── map/                # mapa i filtry
+│   ├── onboarding/         # przewodnik po aplikacji
+│   ├── reports/            # zgłoszenia (lista, formularz, szczegóły, komentarze)
+│   ├── settings/         # profil, powiadomienia, o aplikacji
+│   ├── shell/              # nawigacja (dolny pasek, IndexedStack)
+│   └── splash/             # ekran startowy podczas inicjalizacji
+├── services/               # auth, raporty, komentarze, storage, powiadomienia
+│   └── offline/            # SQLite, cache, sync, connectivity
 └── main.dart
 
-dataconnect/             # schema, queries, mutations (backend)
-test/                    # testy jednostkowe i widgetów
-android/                 # konfiguracja Android
+dataconnect/                # schema, queries, mutations (backend)
+functions/                  # Cloud Functions (np. push przy upvote)
+docs/                       # dokumentacja projektu
+test/                       # testy jednostkowe i widgetów
+integration_test/           # testy E2E
+android/                    # konfiguracja Android
 ```
 
 ## Zespół

--- a/docs/frontend/README.md
+++ b/docs/frontend/README.md
@@ -1,0 +1,191 @@
+# Dokumentacja frontendu (Flutter)
+
+Aplikacja mobilna **City Issues** — warstwa UI i logika po stronie klienta w katalogu `lib/`.
+
+## Spis treści
+
+- [Przegląd](#przegląd)
+- [Uruchomienie lokalne](#uruchomienie-lokalne)
+- [Architektura](#architektura)
+- [Przepływ aplikacji](#przepływ-aplikacji)
+- [Nawigacja](#nawigacja)
+- [Moduły funkcjonalne](#moduły-funkcjonalne)
+- [Warstwa serwisów](#warstwa-serwisów)
+- [Powiązana dokumentacja](#powiązana-dokumentacja)
+
+## Przegląd
+
+Frontend jest aplikacją **Flutter** (Dart 3.11+) z układem **feature-first**: każda funkcja biznesowa ma własny katalog w `lib/features/`. Wspólna logika komunikacji z backendem, urządzeniem i cache offline znajduje się w `lib/services/`.
+
+Główne założenia:
+
+- UI nie wywołuje bezpośrednio GraphQL — korzysta z singletonów serwisów (`AuthService.instance`, `ReportService.instance` itd.).
+- Stan sesji użytkownika pochodzi ze strumienia Firebase Auth (`AuthGate`).
+- Główna nawigacja po zalogowaniu to `MainShell` z dolnym paskiem i zagnieżdżonym `Navigator`.
+- Przy braku sieci aplikacja pokazuje dane z cache SQLite i kolejkuje wybrane operacje do synchronizacji.
+
+## Uruchomienie lokalne
+
+Szczegóły konfiguracji Firebase, Maps i emulatorów: [README główny](../../README.md#konfiguracja).
+
+```bash
+flutter pub get
+flutter run
+```
+
+Emulator Firebase (opcjonalnie):
+
+```bash
+flutter run --dart-define=USE_FIREBASE_EMULATOR=true --dart-define=EMULATOR_HOST=<adres_lan>
+```
+
+## Architektura
+
+```
+┌─────────────────────────────────────────────────────────┐
+│  lib/features/          ekrany, widgety, przewodnik     │
+│       │                                                 │
+│       ▼                                                 │
+│  lib/services/          logika biznesowa, API, offline  │
+│       │                                                 │
+│       ├── dataconnect_generated/   (GraphQL SDK)        │
+│       ├── firebase_auth / storage / messaging           │
+│       └── offline/         SQLite + sync queue          │
+└─────────────────────────────────────────────────────────┘
+```
+
+| Katalog | Odpowiedzialność |
+|---------|------------------|
+| `lib/app/` | `MaterialApp`, motyw (`theme.dart`), inicjalizacja Firebase i serwisów w `app.dart` |
+| `lib/core/` | Stałe (`app_info.dart`), widgety wspólne (`offline_banner.dart`, `app_loading.dart`), mapowanie błędów dla użytkownika |
+| `lib/features/` | Moduły UI pogrupowane po funkcji (auth, map, reports, settings, shell, onboarding, splash) |
+| `lib/services/` | Singletony: auth, raporty, komentarze, storage, powiadomienia, preferencje, offline |
+| `lib/dataconnect_generated/` | Kod wygenerowany z `dataconnect/` — nie edytować ręcznie |
+
+Szczegóły warstw, bootstrapu i konwencji kodu: [architecture.md](architecture.md).
+
+## Przepływ aplikacji
+
+```mermaid
+flowchart TD
+    main["main.dart"] --> bootstrap["CityIssuesApp._bootstrap()"]
+    bootstrap --> splash["AppSplashScreen"]
+    bootstrap --> authGate["AuthGate"]
+    authGate -->|niezalogowany| login["LoginScreen / RegisterScreen"]
+    authGate -->|zalogowany| shell["MainShell"]
+    shell --> map["MapScreen"]
+    shell --> create["CreateReportScreen"]
+    shell --> myReports["MyReportsScreen"]
+    shell --> settings["SettingsScreen"]
+    shell --> detail["ReportDetailScreen"]
+    shell --> edit["EditReportScreen"]
+```
+
+Podczas `_bootstrap()` inicjalizowane są m.in.:
+
+1. Firebase (`FirebaseBootstrap.initialize()`)
+2. `AuthService` — sesja i profil użytkownika
+3. `AppPreferences` — motyw i akcent
+4. `LocalDatabase` — SQLite pod cache offline
+5. `ConnectivityService` — stan sieci
+6. `NotificationService` — FCM i lokalne powiadomienia
+
+## Nawigacja
+
+### AuthGate
+
+`lib/features/auth/auth_gate.dart` nasłuchuje `AuthService.instance.authStateChanges`. Po przywróceniu sesji pokazuje `MainShell`, w przeciwnym razie `LoginScreen`.
+
+### MainShell
+
+`lib/features/shell/main_shell.dart` to szkielet aplikacji po zalogowaniu:
+
+- **IndexedStack** z czterema głównymi zakładkami: mapa, nowe zgłoszenie, moje zgłoszenia, ustawienia.
+- **Zagnieżdżony Navigator** (`_shellNavigatorKey`) do ekranów szczegółów i edycji zgłoszenia.
+- **OfflineBanner** u góry — reaguje na `ConnectivityService` i stan kolejki sync.
+- **App tour** — onboarding z podświetlaniem elementów UI.
+- **Polling** co 30 s oraz callback z `NotificationService` — odświeżanie listy zgłoszeń na mapie.
+
+Mapowanie indeksów dolnego paska (kolejność wizualna vs. indeks w stacku) jest obsługiwane przez gettery `_navIndex` / `_stackIndex`.
+
+## Moduły funkcjonalne
+
+### `features/auth/`
+
+| Plik | Opis |
+|------|------|
+| `auth_gate.dart` | Router sesji |
+| `screens/login_screen.dart` | Logowanie Google |
+| `screens/register_screen.dart` | Rejestracja Google |
+
+Logowanie e-mail/hasło jest zaimplementowane w `AuthService`, ale nie jest wystawione w UI.
+
+### `features/map/`
+
+| Plik | Opis |
+|------|------|
+| `screens/map_screen.dart` | Mapa Google, markery, ładowanie kategorii i zgłoszeń |
+| `widgets/map_category_filters.dart` | Chipsy filtrów kategorii |
+| `widgets/report_marker_sheet.dart` | Bottom sheet po kliknięciu markera |
+
+Mapa ładuje najpierw kategorie, potem zgłoszenia — zapobiega to pokazywaniu markerów bez poprawnych kolorów filtrów.
+
+### `features/reports/`
+
+| Plik | Opis |
+|------|------|
+| `screens/create_report_screen.dart` | Formularz nowego zgłoszenia |
+| `screens/edit_report_screen.dart` | Edycja własnego zgłoszenia |
+| `screens/my_reports_screen.dart` | Lista zgłoszeń użytkownika |
+| `screens/report_detail_screen.dart` | Szczegóły, upvote, komentarze, akcje właściciela |
+| `widgets/comments_section.dart` | Lista i formularz komentarzy |
+| `widgets/upvote_button.dart` | Przycisk głosu wsparcia |
+| `widgets/report_manage_actions.dart` | Edycja / usuwanie zgłoszenia |
+| `widgets/report_location_picker.dart` | Wybór lokalizacji na mapie |
+| `widgets/photo_viewer.dart` | Podgląd zdjęć |
+
+### `features/settings/`
+
+| Plik | Opis |
+|------|------|
+| `screens/settings_screen.dart` | Motyw, akcent, powiadomienia, pomoc, wylogowanie, usuwanie konta |
+| `screens/about_screen.dart` | Informacje o aplikacji i zespole |
+| `widgets/notification_settings_tile.dart` | Przełącznik push FCM |
+
+### `features/onboarding/`
+
+`app_tour.dart` — kroki przewodnika z GlobalKey do elementów mapy i ustawień.
+
+### `features/splash/`
+
+`app_splash_screen.dart` — ekran ładowania podczas bootstrapu.
+
+## Warstwa serwisów
+
+Pełna referencja metod, mapowanie na zapytania GraphQL i zachowanie offline:
+
+**[`lib/services/README.md`](../../lib/services/README.md)**
+
+Skrót modułów offline:
+
+| Plik | Rola |
+|------|------|
+| `offline/local_database.dart` | SQLite: tabele `cache_entries`, `pending_operations` |
+| `offline/offline_cache_store.dart` | Serializacja cache zgłoszeń, kategorii, komentarzy |
+| `offline/connectivity_service.dart` | Nasłuch zmian połączenia (`connectivity_plus`) |
+| `offline/offline_sync_service.dart` | Kolejka i wysyłka operacji po powrocie online |
+| `offline/offline_exception.dart` | Wyjątek przy wymaganej sieci |
+
+Szczegóły trybu offline: [offline.md](offline.md).  
+Powiadomienia push: [notifications.md](notifications.md).
+
+## Powiązana dokumentacja
+
+| Dokument | Zawartość |
+|----------|-----------|
+| [architecture.md](architecture.md) | Bootstrap, motyw, testy widgetów, konwencje |
+| [offline.md](offline.md) | Cache, kolejka sync, ograniczenia offline |
+| [notifications.md](notifications.md) | FCM, token, Cloud Function, deep link do zgłoszenia |
+| [../../README.md](../../README.md) | Konfiguracja projektu, CI, struktura repo |
+| [../../lib/services/README.md](../../lib/services/README.md) | API serwisów |
+| [../../integration_test/README.md](../../integration_test/README.md) | Testy E2E |

--- a/docs/frontend/architecture.md
+++ b/docs/frontend/architecture.md
@@ -1,0 +1,114 @@
+# Architektura frontendu
+
+## Warstwy
+
+### Prezentacja (`lib/features/`)
+
+Ekrany są `StatefulWidget` lub `StatelessWidget`. Stan lokalny (formularze, ładowanie) pozostaje w widoku; dane z backendu pobierane są przez serwisy w `initState`, `FutureBuilder` lub po akcjach użytkownika.
+
+Wspólne wzorce:
+
+- **GlobalKey** do odświeżania ekranów z `MainShell` (`MapScreenState`, `MyReportsScreenState`).
+- **Callbacki** z `NotificationService` do nawigacji i odświeżania bez tight coupling między modułami.
+- **UserFacingError** (`lib/core/utils/user_facing_error.dart`) — spójne komunikaty błędów po polsku.
+
+### Serwisy (`lib/services/`)
+
+Każdy serwis to singleton z konstruktorem prywatnym i `static final instance`. Ułatwia to testowanie (opcjonalne wstrzykiwanie zależności w konstruktorze fabrycznym, np. `AuthService.forTesting`).
+
+Serwisy:
+
+- mapują odpowiedzi Data Connect na modele domenowe używane w UI,
+- obsługują upload do Storage,
+- integrują cache offline tam, gdzie ma to sens (`ReportService`, `CommentService`).
+
+### Core (`lib/core/`)
+
+Elementy wielokrotnego użytku niezwiązane z jedną funkcją:
+
+- `constants/app_info.dart` — wersja, opis, lista twórców (zsynchronizowana z `pubspec.yaml`),
+- `widgets/offline_banner.dart` — pasek „Brak połączenia” / „Synchronizacja…”,
+- `widgets/app_loading.dart` — spinner z opcjonalnym komunikatem.
+
+### Aplikacja (`lib/app/`)
+
+| Plik | Rola |
+|------|------|
+| `app.dart` | `CityIssuesApp` — bootstrap i `MaterialApp` z `AuthGate` |
+| `theme.dart` | Motyw jasny/ciemny, paleta akcentów |
+| `firebase_bootstrap.dart` | Inicjalizacja Firebase, opcjonalnie emulatory |
+
+## Bootstrap
+
+Kolejność inicjalizacji w `CityIssuesApp._bootstrap()`:
+
+```
+FirebaseBootstrap → AuthService → AppPreferences → LocalDatabase → ConnectivityService → NotificationService
+```
+
+Błąd inicjalizacji wyświetla ekran z komunikatem zamiast `AuthGate`.
+
+## Motyw i preferencje
+
+`AppPreferences` (SharedPreferences) przechowuje:
+
+- tryb motywu (system / jasny / ciemny),
+- wybrany kolor akcentu.
+
+`CityIssuesApp` buduje `ThemeData` przez `AppTheme` przy każdej zmianie preferencji (`ListenableBuilder` lub odpowiednik w `app.dart`).
+
+## Generowany SDK
+
+`lib/dataconnect_generated/` powstaje poleceniem:
+
+```bash
+firebase dataconnect:sdk:generate
+```
+
+Pliki w tym katalogu **nie powinny być edytowane ręcznie**. Serwisy importują `default.dart` i wywołują wygenerowane buildery zapytań i mutacji.
+
+## Testy frontendu
+
+| Katalog | Zakres |
+|---------|--------|
+| `test/unit/` | Funkcje czyste, mapowanie błędów, logika offline |
+| `test/widgets/` | Pojedyncze ekrany i widgety z mockami serwisów |
+| `test/helpers/` | `pumpApp`, fixture'y danych |
+| `integration_test/` | Scenariusze na urządzeniu / emulatorze |
+
+Uruchomienie:
+
+```bash
+flutter test
+flutter test test/widgets/
+flutter test integration_test/
+```
+
+Przy testach widgetów serwisy można podmieniać przez konstruktory testowe lub mocki (`firebase_auth_mocks` w dev_dependencies).
+
+## Konwencje
+
+- Importy pakietu: `package:city_issues/...`
+- Nazwy plików: `snake_case.dart`
+- Ekrany: sufiks `_screen.dart` w `screens/`
+- Widgety współdzielone w module: `widgets/`
+- Komunikaty UI po polsku; identyfikatory w kodzie po angielsku
+- Nowa funkcja biznesowa → nowy podkatalog w `features/` z `screens/` i opcjonalnie `widgets/`
+- Logika API → rozszerzenie lub nowy plik w `services/`, dokumentacja w `lib/services/README.md`
+
+## Zależności UI (pubspec.yaml)
+
+Kluczowe pakiety po stronie frontendu:
+
+| Pakiet | Użycie |
+|--------|--------|
+| `google_maps_flutter` | Mapa zgłoszeń |
+| `geolocator` | Pozycja GPS |
+| `image_picker` | Zdjęcia z aparatu / galerii |
+| `flutter_svg` | Logo i ikony SVG |
+| `sqflite`, `path_provider` | Cache offline |
+| `connectivity_plus` | Wykrywanie sieci |
+| `firebase_messaging`, `flutter_local_notifications` | Push |
+| `shared_preferences` | Ustawienia lokalne |
+
+Pełna lista: `pubspec.yaml`.

--- a/docs/frontend/notifications.md
+++ b/docs/frontend/notifications.md
@@ -1,0 +1,67 @@
+# Powiadomienia push (frontend)
+
+Aplikacja wysyła powiadomienia **właścicielowi zgłoszenia**, gdy ktoś inny doda głos wsparcia (upvote). Implementacja opiera się na Firebase Cloud Messaging (FCM), lokalnych powiadomieniach na Androidzie oraz Cloud Function po stronie backendu.
+
+## Przepływ
+
+```mermaid
+sequenceDiagram
+    participant User as Użytkownik A (głosuje)
+    participant App as ReportService
+    participant CF as Cloud Function
+    participant FCM as FCM
+    participant Owner as Właściciel zgłoszenia
+
+    User->>App: upvoteReport()
+    App->>App: mutacja UpvoteReport (Data Connect)
+    App->>CF: notifyUpvoteOnReport(reportId)
+    CF->>FCM: push na token właściciela
+    FCM->>Owner: powiadomienie systemowe
+    Owner->>App: tap → ReportDetailScreen
+```
+
+## NotificationService
+
+Plik: `lib/services/notification_service.dart`
+
+| Etap | Działanie |
+|------|-----------|
+| `initialize()` | Kanał Android, handlery FCM (foreground / background / terminated), integracja z `flutter_local_notifications` |
+| `syncToken()` | Pobranie tokena FCM i zapis w profilu (`UpdateFcmToken` przez Data Connect) |
+| `disablePushRegistration()` | Wyczyszczenie tokena w FCM i w bazie — używane przy wyłączeniu w ustawieniach |
+| `notifyUpvoteOnReport()` | Wywołanie Cloud Function po udanym upvote (region `europe-central2`) |
+
+Callbacki rejestrowane w `MainShell`:
+
+- `setOnReportOpened` — nawigacja do `ReportDetailScreen` po kliknięciu powiadomienia,
+- `setOnReportsChanged` — odświeżenie mapy i list po otrzymaniu push w tle.
+
+## Ustawienia użytkownika
+
+`lib/features/settings/widgets/notification_settings_tile.dart`:
+
+- sprawdza zgodę systemową (`systemPermissionStatus`),
+- włącza sync tokena lub wywołuje `disablePushRegistration`,
+- stan przełącznika powiązany z `AppPreferences` / profilem.
+
+## Polling jako uzupełnienie
+
+`MainShell` uruchamia `Timer.periodic` (30 s), który odświeża zgłoszenia z serwera. Dzięki temu mapa aktualizuje się nawet bez interakcji z powiadomieniem (np. gdy push jest wyłączony).
+
+## Wymagania konfiguracyjne
+
+- Firebase Cloud Messaging włączone w projekcie,
+- `google-services.json` z poprawną konfiguracją FCM,
+- wdrożona Cloud Function `notifyUpvoteOnReport` w `functions/`,
+- na urządzeniu: zgoda na powiadomienia (Android 13+).
+
+Szczegóły backendu funkcji — katalog `functions/` i dokumentacja DevOps w repo.
+
+## Powiązane pliki
+
+| Plik | Rola |
+|------|------|
+| `lib/app/app.dart` | `NotificationService.instance.initialize()` w bootstrapie |
+| `lib/features/shell/main_shell.dart` | Callbacki, polling, `syncToken()` przy starcie |
+| `lib/services/report_service.dart` | Wywołanie `notifyUpvoteOnReport` po upvote |
+| `lib/services/README.md` | Tabela metod `NotificationService` |

--- a/docs/frontend/offline.md
+++ b/docs/frontend/offline.md
@@ -1,0 +1,84 @@
+# Tryb offline (frontend)
+
+Tryb offline działa **wyłącznie po stronie aplikacji mobilnej**. Nie zastępuje backendu — przy braku sieci użytkownik przegląda ostatnio pobrane dane i może wykonać ograniczony zestaw akcji, które trafiają do kolejki synchronizacji.
+
+## Komponenty
+
+```
+ConnectivityService          OfflineSyncService
+        │                            │
+        ▼                            ▼
+   OfflineBanner              pending_operations
+        │                            │
+        └──────────┬─────────────────┘
+                   ▼
+         ReportService / CommentService
+                   │
+                   ▼
+         OfflineCacheStore → LocalDatabase (SQLite)
+```
+
+| Moduł | Plik |
+|-------|------|
+| Baza SQLite | `lib/services/offline/local_database.dart` |
+| Zapis / odczyt cache | `lib/services/offline/offline_cache_store.dart` |
+| Stan sieci | `lib/services/offline/connectivity_service.dart` |
+| Kolejka operacji | `lib/services/offline/offline_sync_service.dart` |
+| UI | `lib/core/widgets/offline_banner.dart` |
+| Integracja w shellu | `lib/features/shell/main_shell.dart` |
+
+## Co jest cache'owane
+
+Po udanym pobraniu z sieci serwisy zapisują kopie w SQLite:
+
+- wszystkie zgłoszenia na mapę (`getReports`),
+- słownik kategorii (`getCategories`),
+- zgłoszenia użytkownika (`getMyReports`),
+- komentarze pod zgłoszeniem (`getComments`).
+
+Przy błędzie sieci lub `OfflineException` serwis zwraca dane z cache zamiast propagować błąd do UI (o ile cache istnieje).
+
+## Operacje w kolejce sync
+
+Gdy `ConnectivityService` zgłasza brak sieci, następujące akcje są **kolejkowane** zamiast wysyłane od razu:
+
+| Operacja | Serwis |
+|----------|--------|
+| `upvoteReport` | `ReportService` |
+| `removeUpvote` | `ReportService` |
+| `addComment` | `CommentService` |
+
+Po powrocie online `MainShell` wywołuje `OfflineSyncService.instance.syncAll()`. Banner pokazuje stan synchronizacji.
+
+Komentarz dodany offline otrzymuje tymczasowe ID (`CommentService.offlinePendingId`) do czasu potwierdzenia z serwera.
+
+## Operacje wymagające sieci
+
+Bez połączenia **nie** da się m.in.:
+
+- utworzyć, edytować ani usunąć zgłoszenia,
+- edytować ani usunąć komentarza,
+- zalogować się lub usunąć konto,
+- zsynchronizować tokena FCM.
+
+W takich przypadkach serwis rzuca `OfflineException` lub zwraca komunikat błędu mapowany przez `UserFacingError`.
+
+## UI
+
+`OfflineBanner` w `MainShell`:
+
+- wyświetla informację o braku internetu,
+- informuje o trwającej synchronizacji kolejki,
+- nie blokuje interakcji z mapą i listami (layout kolumnowy z `SafeArea` u góry powłoki).
+
+## Mapa — kolejność ładowania
+
+`MapScreen` ładuje **najpierw kategorie**, potem zgłoszenia (`_categoriesLoaded`). Zapobiega to sytuacji, w której markery renderują się bez poprawnych filtrów kolorów lub znikałyby przy błędnym stanie offline podczas startu.
+
+## Rozwój i debugowanie
+
+- Baza: `getDatabasesPath()` + plik `city_issues_offline.db`
+- Tabele: `cache_entries` (klucz + JSON), `pending_operations` (typ, payload, timestamp)
+- Testy jednostkowe offline: `test/unit/offline_*`
+
+Przy zmianie formatu cache rozważ migrację wersji bazy w `LocalDatabase`.

--- a/lib/services/README.md
+++ b/lib/services/README.md
@@ -2,6 +2,8 @@
 
 Katalog zawiera logikę biznesową aplikacji — komunikację z backendem (Firebase Data Connect, Storage, Auth, Cloud Functions) oraz integrację z funkcjami urządzenia. UI w `lib/features/` korzysta z tych serwisów przez singletony (`*.instance`).
 
+Przegląd architektury frontendu: [`docs/frontend/README.md`](../../docs/frontend/README.md).
+
 Backend GraphQL: `dataconnect/default_connector/`. Cloud Function poza tym folderem: `functions/src/index.ts`.
 
 ---


### PR DESCRIPTION
Add docs/frontend/ with architecture, offline mode, and FCM guides. Update root README with current features and tech stack.